### PR TITLE
[lake/paimon] Tiering support to scan and write arrow record batch to paimon

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/CompletedFetch.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/log/CompletedFetch.java
@@ -378,6 +378,18 @@ public abstract class CompletedFetch {
         drain();
     }
 
+    /**
+     * Advances {@code nextFetchOffset} to the given offset, ensuring it never decreases. A
+     * decreasing offset can happen when an earlier batch in the response is fully skipped (its
+     * entire range is before {@code nextFetchOffset}), and its {@code nextLogOffset()} is less than
+     * the current {@code nextFetchOffset}. Without this guard, subsequent batches whose base offset
+     * falls between the regressed value and the original {@code nextFetchOffset} would bypass the
+     * slice logic and be returned un-trimmed.
+     */
+    private void advanceNextFetchOffset(long offset) {
+        nextFetchOffset = Math.max(nextFetchOffset, offset);
+    }
+
     private void maybeEnsureValid(LogRecordBatch batch) {
         if (isCheckCrcs) {
             if (readContext.isProjectionPushDowned()) {

--- a/fluss-common/src/main/java/org/apache/fluss/lake/batch/ArrowRecordBatch.java
+++ b/fluss-common/src/main/java/org/apache/fluss/lake/batch/ArrowRecordBatch.java
@@ -18,11 +18,32 @@
 package org.apache.fluss.lake.batch;
 
 import org.apache.fluss.annotation.PublicEvolving;
+import org.apache.fluss.record.ArrowBatchData;
 
 /**
- * The Arrow implementation of the RecordBatch interface.
+ * The Arrow implementation of the {@link RecordBatch} interface.
+ *
+ * <p>Wraps an {@link ArrowBatchData} for use by lake writers that support batch writing via {@link
+ * org.apache.fluss.lake.writer.SupportsRecordBatchWrite}.
  *
  * @since 0.7
  */
 @PublicEvolving
-public class ArrowRecordBatch implements RecordBatch {}
+public class ArrowRecordBatch implements RecordBatch, AutoCloseable {
+
+    private final ArrowBatchData arrowBatchData;
+
+    public ArrowRecordBatch(ArrowBatchData arrowBatchData) {
+        this.arrowBatchData = arrowBatchData;
+    }
+
+    /** Returns the underlying {@link ArrowBatchData}. */
+    public ArrowBatchData getArrowBatchData() {
+        return arrowBatchData;
+    }
+
+    @Override
+    public void close() {
+        arrowBatchData.close();
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSourceReader.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSourceReader.java
@@ -90,11 +90,16 @@ public final class TieringSourceReader<WriteResult>
             LakeTieringFactory<WriteResult, ?> lakeTieringFactory,
             Duration pollTimeout) {
         TieringMetrics tieringMetrics = new TieringMetrics(context.metricGroup());
+        ClassLoader userClassLoader = context.getUserCodeClassLoader().asClassLoader();
         return new TieringSourceFetcherManager<>(
                 elementsQueue,
                 () ->
                         new TieringSplitReader<>(
-                                connection, lakeTieringFactory, pollTimeout, tieringMetrics),
+                                connection,
+                                lakeTieringFactory,
+                                userClassLoader,
+                                pollTimeout,
+                                tieringMetrics),
                 context.getConfiguration(),
                 (ignore) -> {});
     }

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSplitReader.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSplitReader.java
@@ -21,7 +21,9 @@ import org.apache.fluss.annotation.VisibleForTesting;
 import org.apache.fluss.client.Connection;
 import org.apache.fluss.client.table.Table;
 import org.apache.fluss.client.table.scanner.ScanRecord;
+import org.apache.fluss.client.table.scanner.log.ArrowScanRecords;
 import org.apache.fluss.client.table.scanner.log.LogScanner;
+import org.apache.fluss.client.table.scanner.log.LogScannerImpl;
 import org.apache.fluss.client.table.scanner.log.ScanRecords;
 import org.apache.fluss.flink.source.reader.BoundedSplitReader;
 import org.apache.fluss.flink.source.reader.RecordAndPos;
@@ -29,11 +31,16 @@ import org.apache.fluss.flink.tiering.source.metrics.TieringMetrics;
 import org.apache.fluss.flink.tiering.source.split.TieringLogSplit;
 import org.apache.fluss.flink.tiering.source.split.TieringSnapshotSplit;
 import org.apache.fluss.flink.tiering.source.split.TieringSplit;
+import org.apache.fluss.lake.batch.ArrowRecordBatch;
 import org.apache.fluss.lake.writer.LakeTieringFactory;
 import org.apache.fluss.lake.writer.LakeWriter;
+import org.apache.fluss.lake.writer.SupportsRecordBatchWrite;
+import org.apache.fluss.metadata.DataLakeFormat;
+import org.apache.fluss.metadata.LogFormat;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.record.ArrowBatchData;
 import org.apache.fluss.utils.CloseableIterator;
 
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
@@ -56,6 +63,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.apache.fluss.utils.Preconditions.checkArgument;
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
@@ -98,6 +107,8 @@ public class TieringSplitReader<WriteResult>
     @Nullable private BoundedSplitReader currentSnapshotSplitReader;
     @Nullable private TieringSnapshotSplit currentSnapshotSplit;
     @Nullable private Integer currentTableNumberOfSplits;
+    // whether the current table uses the Arrow record batch path for tiering
+    @Nullable private Boolean currentTableUseRecordBatchPath;
 
     // map from table bucket to split id
     private final Map<TableBucket, TieringSplit> currentTableSplitsByBucket;
@@ -108,18 +119,21 @@ public class TieringSplitReader<WriteResult>
     private final Set<TieringSplit> currentEmptySplits;
 
     private final TieringMetrics tieringMetrics;
+    private final boolean unshadedArrowAvailable;
 
     public TieringSplitReader(
             Connection connection,
             LakeTieringFactory<WriteResult, ?> lakeTieringFactory,
+            ClassLoader userClassLoader,
             TieringMetrics tieringMetrics) {
-        this(connection, lakeTieringFactory, DEFAULT_POLL_TIMEOUT, tieringMetrics);
+        this(connection, lakeTieringFactory, userClassLoader, DEFAULT_POLL_TIMEOUT, tieringMetrics);
     }
 
     @VisibleForTesting
     protected TieringSplitReader(
             Connection connection,
             LakeTieringFactory<WriteResult, ?> lakeTieringFactory,
+            ClassLoader userClassLoader,
             Duration pollTimeout,
             TieringMetrics tieringMetrics) {
         this.lakeTieringFactory = lakeTieringFactory;
@@ -136,6 +150,7 @@ public class TieringSplitReader<WriteResult>
         this.reachTieringMaxDurationTables = new HashSet<>();
         this.pollTimeout = pollTimeout;
         this.tieringMetrics = tieringMetrics;
+        this.unshadedArrowAvailable = checkUnshadedArrowAvailable(userClassLoader);
     }
 
     @Override
@@ -171,8 +186,22 @@ public class TieringSplitReader<WriteResult>
                 if (reachTieringMaxDurationTables.contains(currentTableId)) {
                     return forceCompleteTieringLogRecords();
                 }
-                ScanRecords scanRecords = currentLogScanner.poll(pollTimeout);
-                return forLogRecords(scanRecords);
+                if (useRecordBatchPath()) {
+                    ArrowScanRecords arrowScanRecords =
+                            ((LogScannerImpl) currentLogScanner).pollRecordBatch(pollTimeout);
+                    return processLogRecords(
+                            arrowScanRecords.buckets(),
+                            arrowScanRecords::records,
+                            this::handleArrowBatchRecords,
+                            TieringSplitReader::closeArrowBatches);
+                } else {
+                    ScanRecords scanRecords = currentLogScanner.poll(pollTimeout);
+                    return processLogRecords(
+                            scanRecords.buckets(),
+                            scanRecords::records,
+                            this::handleLogRecords,
+                            ignored -> {});
+                }
             } else {
                 return emptyTableBucketWriteResultWithSplitIds();
             }
@@ -350,43 +379,73 @@ public class TieringSplitReader<WriteResult>
         return new TableBucketWriteResultWithSplitIds(writeResults, finishedSplitIds);
     }
 
-    private RecordsWithSplitIds<TableBucketWriteResult<WriteResult>> forLogRecords(
-            ScanRecords scanRecords) throws IOException {
+    /**
+     * Determines whether the current table should use the Arrow record batch path for tiering. The
+     * batch path is used when the table is an ARROW format append-only (log) table and the lake
+     * writer supports batch writing.
+     */
+    private boolean useRecordBatchPath() {
+        if (currentTableUseRecordBatchPath != null) {
+            return currentTableUseRecordBatchPath;
+        }
+        TableInfo tableInfo = checkNotNull(currentTable).getTableInfo();
+
+        currentTableUseRecordBatchPath =
+                unshadedArrowAvailable
+                        && !tableInfo.hasPrimaryKey()
+                        && tableInfo.getTableConfig().getLogFormat() == LogFormat.ARROW
+                        && tableInfo.getTableConfig().getDataLakeFormat().get()
+                                == DataLakeFormat.PAIMON;
+        return currentTableUseRecordBatchPath;
+    }
+
+    /**
+     * Generic template method for processing tiering log records. Encapsulates the shared workflow
+     * of bucket traversal, stopping offset checks, LakeWriter management, offset/timestamp
+     * tracking, split completion, and table completion.
+     *
+     * @param buckets the set of buckets that have records
+     * @param recordsExtractor function to extract records for a given bucket
+     * @param handler callback for processing records within a single bucket
+     * @param noStoppingOffsetHandler callback for handling records when no stopping offset exists
+     * @param <R> the record type
+     * @return the write results and finished split IDs
+     * @throws IOException if an I/O error occurs during processing
+     */
+    private <R> RecordsWithSplitIds<TableBucketWriteResult<WriteResult>> processLogRecords(
+            Set<TableBucket> buckets,
+            Function<TableBucket, List<R>> recordsExtractor,
+            BucketRecordsHandler<R> handler,
+            Consumer<List<R>> noStoppingOffsetHandler)
+            throws IOException {
         Map<TableBucket, TableBucketWriteResult<WriteResult>> writeResults = new HashMap<>();
         Map<TableBucket, String> finishedSplitIds = new HashMap<>();
 
-        for (TableBucket bucket : scanRecords.buckets()) {
-            List<ScanRecord> bucketScanRecords = scanRecords.records(bucket);
-            if (bucketScanRecords.isEmpty()) {
+        for (TableBucket bucket : buckets) {
+            List<R> records = recordsExtractor.apply(bucket);
+            if (records.isEmpty()) {
                 continue;
             }
-            // no any stopping offset, just skip handle the records for the bucket
+
             Long stoppingOffset = currentTableStoppingOffsets.get(bucket);
             if (stoppingOffset == null) {
+                noStoppingOffsetHandler.accept(records);
                 continue;
             }
-            LakeWriter<WriteResult> lakeWriter = null;
-            for (ScanRecord record : bucketScanRecords) {
-                // if record is less than stopping offset
-                if (record.logOffset() < stoppingOffset) {
-                    if (lakeWriter == null) {
-                        lakeWriter =
-                                getOrCreateLakeWriter(
-                                        bucket,
-                                        currentTableSplitsByBucket.get(bucket).getPartitionName());
-                    }
-                    lakeWriter.write(record);
-                    if (record.getSizeInBytes() > 0) {
-                        tieringMetrics.recordBytesRead(record.getSizeInBytes());
-                    }
-                }
+
+            LakeWriter<WriteResult> lakeWriter =
+                    getOrCreateLakeWriter(
+                            bucket, currentTableSplitsByBucket.get(bucket).getPartitionName());
+
+            LogOffsetAndTimestamp lastOffsetAndTimestamp =
+                    handler.handleRecords(records, lakeWriter, stoppingOffset);
+
+            if (lastOffsetAndTimestamp.logOffset >= 0) {
+                currentTableTieredOffsetAndTimestamp.put(bucket, lastOffsetAndTimestamp);
             }
-            ScanRecord lastRecord = bucketScanRecords.get(bucketScanRecords.size() - 1);
-            currentTableTieredOffsetAndTimestamp.put(
-                    bucket,
-                    new LogOffsetAndTimestamp(lastRecord.logOffset(), lastRecord.timestamp()));
-            // has arrived into the end of the split,
-            if (lastRecord.logOffset() >= stoppingOffset - 1) {
+
+            // has arrived into the end of the split
+            if (lastOffsetAndTimestamp.logOffset >= stoppingOffset - 1) {
                 currentTableStoppingOffsets.remove(bucket);
                 if (bucket.getPartitionId() != null) {
                     currentLogScanner.unsubscribe(bucket.getPartitionId(), bucket.getBucket());
@@ -396,15 +455,13 @@ public class TieringSplitReader<WriteResult>
                 }
                 TieringSplit currentTieringSplit = currentTableSplitsByBucket.remove(bucket);
                 String currentSplitId = currentTieringSplit.splitId();
-                // put write result of the bucket
                 writeResults.put(
                         bucket,
                         completeLakeWriter(
                                 bucket,
                                 currentTieringSplit.getPartitionName(),
                                 stoppingOffset,
-                                lastRecord.timestamp()));
-                // put split of the bucket
+                                lastOffsetAndTimestamp.timestamp));
                 finishedSplitIds.put(bucket, currentSplitId);
                 LOG.info(
                         "Finish tier bucket {} for table {}, split: {}.",
@@ -419,6 +476,68 @@ public class TieringSplitReader<WriteResult>
         }
 
         return new TableBucketWriteResultWithSplitIds(writeResults, finishedSplitIds);
+    }
+
+    /** Handles row-based ScanRecord writing for the log path. */
+    private LogOffsetAndTimestamp handleLogRecords(
+            List<ScanRecord> records, LakeWriter<?> lakeWriter, long stoppingOffset)
+            throws IOException {
+        long lastWrittenOffset = -1;
+        long lastWrittenTimestamp = -1;
+        for (ScanRecord record : records) {
+            if (record.logOffset() < stoppingOffset) {
+                lakeWriter.write(record);
+                lastWrittenOffset = record.logOffset();
+                lastWrittenTimestamp = record.timestamp();
+                if (record.getSizeInBytes() > 0) {
+                    tieringMetrics.recordBytesRead(record.getSizeInBytes());
+                }
+            }
+        }
+        return new LogOffsetAndTimestamp(lastWrittenOffset, lastWrittenTimestamp);
+    }
+
+    /** Handles Arrow batch writing for the record batch path. */
+    private LogOffsetAndTimestamp handleArrowBatchRecords(
+            List<ArrowBatchData> batches, LakeWriter<?> lakeWriter, long stoppingOffset)
+            throws IOException {
+        SupportsRecordBatchWrite batchWriter = (SupportsRecordBatchWrite) lakeWriter;
+        long lastWrittenBatchEndOffset = -1;
+        long lastWrittenTimestamp = -1;
+        for (ArrowBatchData batch : batches) {
+            long batchBaseOffset = batch.getBaseLogOffset();
+            if (batchBaseOffset >= stoppingOffset) {
+                batch.close();
+                continue;
+            }
+
+            long writableRowCount = stoppingOffset - batchBaseOffset;
+            int writableRows = (int) Math.min(batch.getRecordCount(), writableRowCount);
+            if (writableRows <= 0) {
+                batch.close();
+                continue;
+            }
+
+            ArrowBatchData batchToWrite = batch;
+            if (writableRows < batch.getRecordCount()) {
+                batchToWrite = batch.sliceAndTransferOwnership(0, writableRows);
+            }
+
+            long batchEndOffset = batchBaseOffset + writableRows - 1L;
+            try (ArrowRecordBatch arrowRecordBatch = new ArrowRecordBatch(batchToWrite)) {
+                batchWriter.write(arrowRecordBatch);
+            }
+            lastWrittenBatchEndOffset = batchEndOffset;
+            lastWrittenTimestamp = batchToWrite.getTimestamp();
+        }
+        return new LogOffsetAndTimestamp(lastWrittenBatchEndOffset, lastWrittenTimestamp);
+    }
+
+    /** Closes all Arrow batches in the list to release resources. */
+    private static void closeArrowBatches(List<ArrowBatchData> batches) {
+        for (ArrowBatchData batch : batches) {
+            batch.close();
+        }
     }
 
     private LakeWriter<WriteResult> getOrCreateLakeWriter(
@@ -565,6 +684,7 @@ public class TieringSplitReader<WriteResult>
         currentTableId = null;
         currentTablePath = null;
         currentTableNumberOfSplits = null;
+        currentTableUseRecordBatchPath = null;
         currentPendingSnapshotSplits.clear();
         currentTableStoppingOffsets.clear();
         currentTableTieredOffsetAndTimestamp.clear();
@@ -703,6 +823,39 @@ public class TieringSplitReader<WriteResult>
         @Override
         public Set<String> finishedSplits() {
             return new HashSet<>(bucketSplits.values());
+        }
+    }
+
+    /**
+     * Callback interface for processing records within a single bucket. Encapsulates the
+     * differences in write strategy and offset/timestamp calculation between the row-based
+     * (ScanRecord) and Arrow batch (ArrowBatchData) paths.
+     *
+     * @param <R> the record type (ScanRecord or ArrowBatchData)
+     */
+    @FunctionalInterface
+    private interface BucketRecordsHandler<R> {
+
+        /**
+         * Processes the records for a bucket, writes them to the lake, and returns the last offset
+         * and timestamp.
+         *
+         * @param records the records for this bucket
+         * @param lakeWriter the writer to use for writing to the lake
+         * @param stoppingOffset the stopping offset for this bucket
+         * @return the last offset and timestamp after processing
+         * @throws IOException if an I/O error occurs during writing
+         */
+        LogOffsetAndTimestamp handleRecords(
+                List<R> records, LakeWriter<?> lakeWriter, long stoppingOffset) throws IOException;
+    }
+
+    private static boolean checkUnshadedArrowAvailable(ClassLoader classLoader) {
+        try {
+            Class.forName("org.apache.arrow.vector.VectorSchemaRoot", false, classLoader);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
         }
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringSplitReaderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringSplitReaderTest.java
@@ -341,7 +341,10 @@ class TieringSplitReaderTest extends FlinkTestBase {
                         InternalSourceReaderMetricGroup.mock(
                                 new MetricListener().getMetricGroup()));
         return new TieringSplitReader<>(
-                connection, new TestingLakeTieringFactory(), tieringMetrics);
+                connection,
+                new TestingLakeTieringFactory(),
+                Thread.currentThread().getContextClassLoader(),
+                tieringMetrics);
     }
 
     private TieringSplitReader<TestingWriteResult> createTieringReader(

--- a/fluss-lake/fluss-lake-paimon/pom.xml
+++ b/fluss-lake/fluss-lake-paimon/pom.xml
@@ -52,6 +52,27 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-arrow</artifactId>
+            <version>${paimon.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <version>${arrow.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-netty</artifactId>
+            <version>${arrow.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.fluss</groupId>
             <artifactId>fluss-client</artifactId>
             <version>${project.version}</version>

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/PaimonLakeWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/PaimonLakeWriter.java
@@ -17,9 +17,12 @@
 
 package org.apache.fluss.lake.paimon.tiering;
 
+import org.apache.fluss.lake.batch.ArrowRecordBatch;
+import org.apache.fluss.lake.batch.RecordBatch;
 import org.apache.fluss.lake.paimon.tiering.append.AppendOnlyWriter;
 import org.apache.fluss.lake.paimon.tiering.mergetree.MergeTreeWriter;
 import org.apache.fluss.lake.writer.LakeWriter;
+import org.apache.fluss.lake.writer.SupportsRecordBatchWrite;
 import org.apache.fluss.lake.writer.WriterInitContext;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.record.LogRecord;
@@ -38,7 +41,7 @@ import java.util.Map;
 import static org.apache.fluss.lake.paimon.utils.PaimonConversions.toPaimon;
 
 /** Implementation of {@link LakeWriter} for Paimon. */
-public class PaimonLakeWriter implements LakeWriter<PaimonWriteResult> {
+public class PaimonLakeWriter implements LakeWriter<PaimonWriteResult>, SupportsRecordBatchWrite {
 
     private final Catalog paimonCatalog;
     private final RecordWriter<?> recordWriter;
@@ -77,6 +80,25 @@ public class PaimonLakeWriter implements LakeWriter<PaimonWriteResult> {
             recordWriter.write(record);
         } catch (Exception e) {
             throw new IOException("Failed to write Fluss record to Paimon.", e);
+        }
+    }
+
+    @Override
+    public void write(RecordBatch recordBatch) throws IOException {
+        if (!(recordBatch instanceof ArrowRecordBatch)) {
+            throw new IllegalArgumentException(
+                    "PaimonLakeWriter only supports ArrowRecordBatch, but got "
+                            + recordBatch.getClass().getSimpleName());
+        }
+        if (!(recordWriter instanceof AppendOnlyWriter)) {
+            throw new IllegalStateException(
+                    "Arrow record batch writing is only supported for append-only tables.");
+        }
+        try {
+            ((AppendOnlyWriter) recordWriter)
+                    .writeArrowBatch(((ArrowRecordBatch) recordBatch).getArrowBatchData());
+        } catch (Exception e) {
+            throw new IOException("Failed to write Arrow record batch to Paimon.", e);
         }
     }
 

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/append/AppendOnlyArrowBatchHelper.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/append/AppendOnlyArrowBatchHelper.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.paimon.tiering.append;
+
+import org.apache.fluss.metadata.TableDescriptor;
+import org.apache.fluss.record.ArrowBatchData;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.paimon.arrow.ArrowBundleRecords;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class that encapsulates Arrow-dependent batch writing logic for append-only tables.
+ *
+ * <p>This class is separated from {@link AppendOnlyWriter} to avoid loading Arrow classes when
+ * Arrow is not on the classpath. It is lazily loaded only when Arrow batch writing is actually
+ * needed.
+ */
+class AppendOnlyArrowBatchHelper implements AutoCloseable {
+
+    private final FileStoreTable fileStoreTable;
+    private final TableWriteImpl<InternalRow> tableWrite;
+    private final RowType tableRowType;
+    private final int bucket;
+
+    // Child allocator for system column vectors, sharing the same root as the batch allocator
+    @Nullable private BufferAllocator systemColumnAllocator;
+
+    // Reusable resources for enriched VectorSchemaRoot with system columns
+    @Nullable private VectorSchemaRoot enrichedRoot;
+    @Nullable private Schema enrichedSchema;
+    @Nullable private IntVector bucketVector;
+    @Nullable private BigIntVector offsetVector;
+    @Nullable private TimeStampMilliVector timestampVector;
+
+    AppendOnlyArrowBatchHelper(
+            FileStoreTable fileStoreTable,
+            TableWriteImpl<InternalRow> tableWrite,
+            RowType tableRowType,
+            int bucket) {
+        this.fileStoreTable = fileStoreTable;
+        this.tableWrite = tableWrite;
+        this.tableRowType = tableRowType;
+        this.bucket = bucket;
+    }
+
+    /**
+     * Writes an Arrow batch directly to Paimon Parquet files. Enriches the VectorSchemaRoot with
+     * system columns (__bucket, __offset, __timestamp) and uses Paimon's {@link ArrowBundleRecords}
+     * for efficient batch writing.
+     *
+     * @return the partition derived from the first row, or the passed-in partition if already set
+     */
+    @Nullable
+    BinaryRow writeArrowBatch(ArrowBatchData arrowBatchData, @Nullable BinaryRow partition)
+            throws Exception {
+        int writtenBucket = bucket;
+        if (fileStoreTable.store().bucketMode() == BucketMode.BUCKET_UNAWARE) {
+            writtenBucket = 0;
+        }
+
+        VectorSchemaRoot originalRoot = arrowBatchData.getVectorSchemaRoot();
+        long baseOffset = arrowBatchData.getBaseLogOffset();
+        long timestamp = arrowBatchData.getTimestamp();
+        int rowCount = originalRoot.getRowCount();
+
+        ensureEnrichedRootInitialized(originalRoot, arrowBatchData.getAllocator());
+        updateEnrichedVectorSchemaRoot(writtenBucket, baseOffset, timestamp, rowCount);
+
+        ArrowBundleRecords arrowBundleRecords =
+                new ArrowBundleRecords(enrichedRoot, tableRowType, false);
+
+        // derive partition from the first row if not yet determined
+        if (partition == null) {
+            // TODO: optimize how to get paimon partition
+            InternalRow firstRow = arrowBundleRecords.iterator().next();
+            partition = tableWrite.getPartition(firstRow);
+        }
+
+        tableWrite.writeBundle(partition, writtenBucket, arrowBundleRecords);
+        return partition;
+    }
+
+    /**
+     * Ensures the enriched VectorSchemaRoot is initialized with system column vectors. Reuses
+     * system column vectors if schema matches. The enrichedRoot references the current
+     * originalRoot's data vectors plus the system column vectors.
+     */
+    private void ensureEnrichedRootInitialized(
+            VectorSchemaRoot originalRoot, BufferAllocator batchAllocator) {
+        Schema originalSchema = originalRoot.getSchema();
+        List<Field> originalFields = originalSchema.getFields();
+        int currentFieldCount = originalFields.size();
+
+        // initialize system column vectors on first call, using a child allocator that
+        // shares the same root as the batch allocator so all vectors are compatible
+        if (bucketVector == null) {
+            Field bucketField =
+                    new Field(
+                            TableDescriptor.BUCKET_COLUMN_NAME,
+                            new FieldType(false, new ArrowType.Int(32, true), null),
+                            null);
+            Field offsetField =
+                    new Field(
+                            TableDescriptor.OFFSET_COLUMN_NAME,
+                            new FieldType(false, new ArrowType.Int(64, true), null),
+                            null);
+            Field timestampField =
+                    new Field(
+                            TableDescriptor.TIMESTAMP_COLUMN_NAME,
+                            new FieldType(
+                                    false,
+                                    new ArrowType.Timestamp(TimeUnit.MILLISECOND, null),
+                                    null),
+                            null);
+
+            List<Field> enrichedFields = new ArrayList<>(originalFields);
+            enrichedFields.add(bucketField);
+            enrichedFields.add(offsetField);
+            enrichedFields.add(timestampField);
+            enrichedSchema = new Schema(enrichedFields);
+
+            if (systemColumnAllocator == null) {
+                systemColumnAllocator =
+                        batchAllocator
+                                .getRoot()
+                                .newChildAllocator("system-column-allocator", 0, Long.MAX_VALUE);
+            }
+            bucketVector = new IntVector(bucketField, systemColumnAllocator);
+            offsetVector = new BigIntVector(offsetField, systemColumnAllocator);
+            timestampVector = new TimeStampMilliVector(timestampField, systemColumnAllocator);
+        }
+
+        // recreate enrichedRoot to reference the current originalRoot's data vectors
+        List<FieldVector> allVectors = new ArrayList<>();
+        for (int i = 0; i < currentFieldCount; i++) {
+            allVectors.add(originalRoot.getVector(i));
+        }
+        allVectors.add(bucketVector);
+        allVectors.add(offsetVector);
+        allVectors.add(timestampVector);
+
+        enrichedRoot = new VectorSchemaRoot(enrichedSchema, allVectors, originalRoot.getRowCount());
+    }
+
+    /**
+     * Updates system column values in the enriched VectorSchemaRoot. Data columns are already
+     * referenced from the original root.
+     */
+    private void updateEnrichedVectorSchemaRoot(
+            int bucket, long baseOffset, long timestamp, int rowCount) {
+        enrichedRoot.setRowCount(rowCount);
+
+        if (bucketVector.getValueCapacity() < rowCount) {
+            bucketVector.allocateNew(rowCount);
+        }
+        if (offsetVector.getValueCapacity() < rowCount) {
+            offsetVector.allocateNew(rowCount);
+        }
+        if (timestampVector.getValueCapacity() < rowCount) {
+            timestampVector.allocateNew(rowCount);
+        }
+
+        for (int i = 0; i < rowCount; i++) {
+            bucketVector.set(i, bucket);
+        }
+        bucketVector.setValueCount(rowCount);
+
+        for (int i = 0; i < rowCount; i++) {
+            offsetVector.set(i, baseOffset + i);
+        }
+        offsetVector.setValueCount(rowCount);
+
+        for (int i = 0; i < rowCount; i++) {
+            timestampVector.set(i, timestamp);
+        }
+        timestampVector.setValueCount(rowCount);
+    }
+
+    @Override
+    public void close() {
+        if (bucketVector != null) {
+            bucketVector.close();
+            bucketVector = null;
+        }
+        if (offsetVector != null) {
+            offsetVector.close();
+            offsetVector = null;
+        }
+        if (timestampVector != null) {
+            timestampVector.close();
+            timestampVector = null;
+        }
+        if (systemColumnAllocator != null) {
+            systemColumnAllocator.close();
+            systemColumnAllocator = null;
+        }
+        enrichedRoot = null;
+        enrichedSchema = null;
+    }
+}

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/append/AppendOnlyWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/tiering/append/AppendOnlyWriter.java
@@ -19,9 +19,11 @@ package org.apache.fluss.lake.paimon.tiering.append;
 
 import org.apache.fluss.lake.paimon.tiering.RecordWriter;
 import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.record.ArrowBatchData;
 import org.apache.fluss.record.LogRecord;
 import org.apache.fluss.types.RowType;
 
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
@@ -37,6 +39,13 @@ import static org.apache.fluss.lake.paimon.tiering.PaimonLakeTieringFactory.FLUS
 public class AppendOnlyWriter extends RecordWriter<InternalRow> {
 
     private final FileStoreTable fileStoreTable;
+
+    /**
+     * Lazily-initialized helper for Arrow batch writing. Stored as {@link AutoCloseable} to avoid
+     * loading Arrow classes when Arrow is not on the classpath. The actual type is {@link
+     * AppendOnlyArrowBatchHelper} which is only loaded when {@link #writeArrowBatch} is called.
+     */
+    @Nullable private AutoCloseable arrowBatchHelper;
 
     public AppendOnlyWriter(
             FileStoreTable fileStoreTable,
@@ -70,5 +79,35 @@ public class AppendOnlyWriter extends RecordWriter<InternalRow> {
             writtenBucket = 0;
         }
         tableWrite.getWrite().write(partition, writtenBucket, flussRecordAsPaimonRow);
+    }
+
+    /**
+     * Writes an Arrow batch directly to Paimon Parquet files. Delegates to {@link
+     * AppendOnlyArrowBatchHelper} which is lazily loaded to avoid class loading issues when Arrow
+     * is not on the classpath.
+     */
+    public void writeArrowBatch(ArrowBatchData arrowBatchData) throws Exception {
+        AppendOnlyArrowBatchHelper helper;
+        if (arrowBatchHelper == null) {
+            helper =
+                    new AppendOnlyArrowBatchHelper(
+                            fileStoreTable, tableWrite, tableRowType, bucket);
+            arrowBatchHelper = helper;
+        } else {
+            helper = (AppendOnlyArrowBatchHelper) arrowBatchHelper;
+        }
+        BinaryRow derivedPartition = helper.writeArrowBatch(arrowBatchData, partition);
+        if (partition == null) {
+            partition = derivedPartition;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (arrowBatchHelper != null) {
+            arrowBatchHelper.close();
+            arrowBatchHelper = null;
+        }
+        super.close();
     }
 }

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
@@ -1,0 +1,587 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.arrow.converter;
+
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.columnar.ArrayColumnVector;
+import org.apache.paimon.data.columnar.BooleanColumnVector;
+import org.apache.paimon.data.columnar.ByteColumnVector;
+import org.apache.paimon.data.columnar.BytesColumnVector;
+import org.apache.paimon.data.columnar.ColumnVector;
+import org.apache.paimon.data.columnar.ColumnarArray;
+import org.apache.paimon.data.columnar.ColumnarMap;
+import org.apache.paimon.data.columnar.ColumnarRow;
+import org.apache.paimon.data.columnar.DecimalColumnVector;
+import org.apache.paimon.data.columnar.DoubleColumnVector;
+import org.apache.paimon.data.columnar.FloatColumnVector;
+import org.apache.paimon.data.columnar.IntColumnVector;
+import org.apache.paimon.data.columnar.LongColumnVector;
+import org.apache.paimon.data.columnar.MapColumnVector;
+import org.apache.paimon.data.columnar.RowColumnVector;
+import org.apache.paimon.data.columnar.ShortColumnVector;
+import org.apache.paimon.data.columnar.TimestampColumnVector;
+import org.apache.paimon.data.columnar.VectorizedColumnBatch;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.BinaryType;
+import org.apache.paimon.types.BooleanType;
+import org.apache.paimon.types.CharType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeVisitor;
+import org.apache.paimon.types.DateType;
+import org.apache.paimon.types.DecimalType;
+import org.apache.paimon.types.DoubleType;
+import org.apache.paimon.types.FloatType;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.MultisetType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.SmallIntType;
+import org.apache.paimon.types.TimeType;
+import org.apache.paimon.types.TimestampType;
+import org.apache.paimon.types.TinyIntType;
+import org.apache.paimon.types.VarBinaryType;
+import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Convert a {@link FieldVector} to {@link ColumnVector}.
+ *
+ * <p>This is copied from Paimon and fixes bugs for {@code LocalZonedTimestampType} (should use
+ * {@code ((TimeStampVector) vector).get(i)} instead of {@code (long) vector.getObject(i)}) and
+ * {@code BinaryType} (should use {@code FixedSizeBinaryVector} instead of {@code VarBinaryVector}).
+ */
+public interface Arrow2PaimonVectorConverter {
+
+    static Arrow2PaimonVectorConverter construct(DataType type) {
+        return type.accept(Arrow2PaimonVectorConvertorVisitor.INSTANCE);
+    }
+
+    ColumnVector convertVector(FieldVector vector);
+
+    /** Visitor to create convertor from arrow to paimon. */
+    class Arrow2PaimonVectorConvertorVisitor
+            implements DataTypeVisitor<Arrow2PaimonVectorConverter> {
+
+        private static final Arrow2PaimonVectorConvertorVisitor INSTANCE =
+                new Arrow2PaimonVectorConvertorVisitor();
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(CharType charType) {
+            return vector ->
+                    new BytesColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public Bytes getBytes(int index) {
+                            byte[] bytes;
+                            if (vector instanceof FixedSizeBinaryVector) {
+                                bytes = ((FixedSizeBinaryVector) vector).get(index);
+                            } else {
+                                bytes = ((VarCharVector) vector).get(index);
+                            }
+
+                            return new Bytes(bytes, 0, bytes.length) {
+                                @Override
+                                public byte[] getBytes() {
+                                    return bytes;
+                                }
+                            };
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(VarCharType varCharType) {
+            return vector ->
+                    new BytesColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public Bytes getBytes(int index) {
+                            byte[] bytes = ((VarCharVector) vector).get(index);
+                            return new Bytes(bytes, 0, bytes.length) {
+                                @Override
+                                public byte[] getBytes() {
+                                    return bytes;
+                                }
+                            };
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(BooleanType booleanType) {
+            return vector ->
+                    new BooleanColumnVector() {
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public boolean getBoolean(int index) {
+                            return ((BitVector) vector).getObject(index);
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(BinaryType binaryType) {
+            return vector ->
+                    new BytesColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public Bytes getBytes(int index) {
+                            byte[] bytes = ((FixedSizeBinaryVector) vector).get(index);
+                            return new Bytes(bytes, 0, bytes.length) {
+                                @Override
+                                public byte[] getBytes() {
+                                    return bytes;
+                                }
+                            };
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(VarBinaryType varBinaryType) {
+            return vector ->
+                    new BytesColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public Bytes getBytes(int index) {
+                            byte[] bytes = ((VarBinaryVector) vector).get(index);
+                            return new Bytes(bytes, 0, bytes.length) {
+                                @Override
+                                public byte[] getBytes() {
+                                    return bytes;
+                                }
+                            };
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(DecimalType decimalType) {
+            return vector ->
+                    new DecimalColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public Decimal getDecimal(int index, int precision, int scale) {
+                            return Decimal.fromBigDecimal(
+                                    ((DecimalVector) vector).getObject(index), precision, scale);
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(TinyIntType tinyIntType) {
+            return vector ->
+                    new ByteColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public byte getByte(int index) {
+                            return ((TinyIntVector) vector).getObject(index);
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(SmallIntType smallIntType) {
+            return vector ->
+                    new ShortColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public short getShort(int index) {
+                            return ((SmallIntVector) vector).getObject(index);
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(IntType intType) {
+            return vector ->
+                    new IntColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public int getInt(int index) {
+                            return ((IntVector) vector).getObject(index);
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(BigIntType bigIntType) {
+            return vector ->
+                    new LongColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public long getLong(int index) {
+                            return ((BigIntVector) vector).getObject(index);
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(FloatType floatType) {
+            return vector ->
+                    new FloatColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public float getFloat(int index) {
+                            return ((Float4Vector) vector).getObject(index);
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(DoubleType doubleType) {
+            return vector ->
+                    new DoubleColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public double getDouble(int index) {
+                            return ((Float8Vector) vector).getObject(index);
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(DateType dateType) {
+            return vector ->
+                    new IntColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public int getInt(int index) {
+                            return ((DateDayVector) vector).getObject(index);
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(TimeType timeType) {
+            return vector ->
+                    new IntColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public int getInt(int index) {
+                            return ((TimeMilliVector) vector).get(index);
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(TimestampType timestampType) {
+            return vector ->
+                    new TimestampColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public Timestamp getTimestamp(int i, int precision) {
+                            long value = ((TimeStampVector) vector).get(i);
+                            if (precision == 0) {
+                                return Timestamp.fromEpochMillis(value * 1000);
+                            } else if (precision >= 1 && precision <= 3) {
+                                return Timestamp.fromEpochMillis(value);
+                            } else if (precision >= 4 && precision <= 6) {
+                                return Timestamp.fromMicros(value);
+                            } else {
+                                return Timestamp.fromEpochMillis(
+                                        value / 1_000_000, (int) (value % 1_000_000));
+                            }
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(LocalZonedTimestampType localZonedTimestampType) {
+            return vector ->
+                    new TimestampColumnVector() {
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public Timestamp getTimestamp(int i, int precision) {
+                            long value = ((TimeStampVector) vector).get(i);
+                            if (precision == 0) {
+                                return Timestamp.fromEpochMillis(value * 1000);
+                            } else if (precision >= 1 && precision <= 3) {
+                                return Timestamp.fromEpochMillis(value);
+                            } else if (precision >= 4 && precision <= 6) {
+                                return Timestamp.fromMicros(value);
+                            } else {
+                                return Timestamp.fromEpochMillis(
+                                        value / 1_000_000, (int) (value % 1_000_000));
+                            }
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(VariantType variantType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(ArrayType arrayType) {
+            final Arrow2PaimonVectorConverter arrowVectorConvertor =
+                    arrayType.getElementType().accept(this);
+
+            return vector ->
+                    new ArrayColumnVector() {
+
+                        private boolean inited = false;
+                        private ColumnVector columnVector;
+
+                        private void init() {
+                            if (!inited) {
+                                FieldVector child = ((ListVector) vector).getDataVector();
+                                this.columnVector = arrowVectorConvertor.convertVector(child);
+                                inited = true;
+                            }
+                        }
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public InternalArray getArray(int index) {
+                            init();
+                            ListVector listVector = (ListVector) vector;
+                            int start = listVector.getElementStartIndex(index);
+                            int end = listVector.getElementEndIndex(index);
+                            return new ColumnarArray(columnVector, start, end - start);
+                        }
+
+                        @Override
+                        public ColumnVector getColumnVector() {
+                            init();
+                            return columnVector;
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(MultisetType multisetType) {
+            throw new UnsupportedOperationException("Doesn't support MultisetType.");
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(MapType mapType) {
+            final Arrow2PaimonVectorConverter keyConvertor = mapType.getKeyType().accept(this);
+            final Arrow2PaimonVectorConverter valueConverter = mapType.getValueType().accept(this);
+
+            return vector ->
+                    new MapColumnVector() {
+
+                        private boolean inited = false;
+                        private ListVector mapVector;
+                        private ColumnVector keyColumnVector;
+                        private ColumnVector valueColumnVector;
+
+                        private void init() {
+                            if (!inited) {
+                                this.mapVector = (ListVector) vector;
+                                StructVector listVector = (StructVector) mapVector.getDataVector();
+
+                                FieldVector keyVector = listVector.getChildrenFromFields().get(0);
+                                FieldVector valueVector = listVector.getChildrenFromFields().get(1);
+
+                                this.keyColumnVector = keyConvertor.convertVector(keyVector);
+                                this.valueColumnVector = valueConverter.convertVector(valueVector);
+                                inited = true;
+                            }
+                        }
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public InternalMap getMap(int index) {
+                            init();
+
+                            int start = mapVector.getElementStartIndex(index);
+                            int end = mapVector.getElementEndIndex(index);
+
+                            return new ColumnarMap(
+                                    keyColumnVector, valueColumnVector, start, end - start);
+                        }
+
+                        @Override
+                        public ColumnVector[] getChildren() {
+                            return new ColumnVector[] {keyColumnVector, valueColumnVector};
+                        }
+                    };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(RowType rowType) {
+            final List<Arrow2PaimonVectorConverter> convertors = new ArrayList<>();
+            final List<String> names = new ArrayList<>();
+            List<DataField> fields = rowType.getFields();
+            for (int i = 0; i < rowType.getFields().size(); i++) {
+                convertors.add(rowType.getTypeAt(i).accept(this));
+                names.add(fields.get(i).name());
+            }
+
+            return vector ->
+                    new RowColumnVector() {
+
+                        private boolean inited = false;
+                        private VectorizedColumnBatch vectorizedColumnBatch;
+
+                        private void init() {
+                            if (!inited) {
+                                List<FieldVector> children =
+                                        ((StructVector) vector).getChildrenFromFields();
+                                ColumnVector[] vectors = new ColumnVector[convertors.size()];
+
+                                for (FieldVector child : children) {
+                                    int index = names.indexOf(child.getName());
+                                    if (index != -1) {
+                                        vectors[index] = convertors.get(index).convertVector(child);
+                                    }
+                                }
+
+                                this.vectorizedColumnBatch = new VectorizedColumnBatch(vectors);
+                                inited = true;
+                            }
+                        }
+
+                        @Override
+                        public boolean isNullAt(int index) {
+                            return vector.isNull(index);
+                        }
+
+                        @Override
+                        public InternalRow getRow(int index) {
+                            init();
+                            return new ColumnarRow(vectorizedColumnBatch, index);
+                        }
+
+                        @Override
+                        public VectorizedColumnBatch getBatch() {
+                            init();
+                            return vectorizedColumnBatch;
+                        }
+                    };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adjust `TieringSplitReader` to support scanning Arrow record batches and writing them directly to Paimon via `SupportsRecordBatchWrite`
- Add `Arrow2PaimonVectorConverter` for converting Arrow vectors to Paimon columnar vectors
- Add `AppendOnlyArrowBatchHelper` for writing Arrow batches to Paimon append-only tables
- Add runtime check for unshaded Arrow availability to gracefully fall back to row-based path
- Fix `CompletedFetch` to support fetching Arrow batches with offset skipping and `advanceNextFetchOffset` guard

Depends on https://github.com/apache/fluss/pull/2995

Closes https://github.com/apache/fluss/issues/2966